### PR TITLE
bug fixing and porting to python 3

### DIFF
--- a/Filter.py
+++ b/Filter.py
@@ -5,36 +5,35 @@
 
 
 import textwrap
+
 from Id import Id
 
+
 class Filter:
-	COLOR = '#999999'
+    COLOR = '#999999'
 
+    def __init__(self, spec=None):
+        self.__parent = None
+        self.__target = None
+        self.__params = []
 
-	def __init__(self, spec = None):
-		self.__parent = None
-		self.__target = None
-		self.__params = []
+        if spec is not None:
+            self.parseSpec(spec)
 
-		if spec is not None:
-			self.parseSpec(spec)
+    def parseSpec(self, spec):
+        spec = spec.split(' ')[2:]
+        self.__parent = Id(spec.pop(0))
 
+        while spec:
+            item = spec.pop(0)
+            if item == 'classid' or item == 'flowid':
+                self.__target = Id(spec.pop(0))
+            else:
+                self.__params.append(item)
 
-	def parseSpec(self, spec):
-		spec = spec.split(' ')[2:]
-		self.__parent = Id(spec.pop(0))
-
-		while spec:
-			item = spec.pop(0)
-			if item == 'classid' or item == 'flowid':
-				self.__target = Id(spec.pop(0))
-			else:
-				self.__params.append(item)
-
-
-	def getEdgeSpec(self):
-		if self.__target is None:
-			return ''
-		label = '<br/>'.join(textwrap.wrap(' '.join(self.__params), 20))
-		fmt = '"%s" -> "%s" [ arrowhead = "vee", color = "%s", label = <<font point-size="10" color="%s">%s</font>>, style = "dotted" ];'
-		return fmt % (self.__parent, self.__target, self.COLOR, self.COLOR, label)
+    def getEdgeSpec(self):
+        if self.__target is None:
+            return ''
+        label = '<br/>'.join(textwrap.wrap(' '.join(self.__params), 20))
+        fmt = '"%s" -> "%s" [ arrowhead = "vee", color = "%s", label = <<font point-size="10" color="%s">%s</font>>, style = "dotted" ];'
+        return fmt % (self.__parent, self.__target, self.COLOR, self.COLOR, label)

--- a/Id.py
+++ b/Id.py
@@ -5,21 +5,10 @@
 
 
 class Id:
-	def __init__(self, spec = '1:0'):
-		(self.__major, self.__minor) = map(self.__parseId, spec.split(':'))
+    def __init__(self, spec='1:0'):
+        (self._major, self._minor) = spec.split(':')
 
+    def __str__(self):
+        return '%s:%s' % (self._major, self._minor)
 
-	def __parseId(self, id):
-		'''Parse a major or minor number.'''
-		if not id:
-			return 0
-		else:
-			return int(id, 16)
-
-
-	def __str__(self):
-		return '%x:%x' % (self.__major, self.__minor)
-
-
-	__unicode__ = __repr__ = __str__
-
+    __unicode__ = __repr__ = __str__

--- a/Node.py
+++ b/Node.py
@@ -5,58 +5,54 @@
 
 
 import textwrap
+
 from Id import Id
 
 
 class Node:
-	def __init__(self, spec = None):
-		self.__id = None
-		self.__nodeType = None
-		self.__parent = None
-		self.__type = None
-		self.__params = []
+    def __init__(self, spec=None):
+        self._id = None
+        self._nodeType = None
+        self._parent = None
+        self._type = None
+        self._params = []
 
-		if spec is not None:
-			self.parseSpec(spec)
+        if spec is not None:
+            self.parseSpec(spec)
 
+    def parseSpec(self, spec):
+        spec = spec.split(' ')
+        self._nodeType = spec.pop(0)
+        self._type = spec.pop(0)
+        self._id = Id(spec.pop(0))
+        if spec.pop(0) == 'parent':
+            self._parent = Id(spec.pop(0))
+        else:
+            self._parent = Id("{}:".format(self._id._major)) if self._nodeType == 'class' else None
 
-	def parseSpec(self, spec):
-		spec = spec.split(' ')
-		self.__nodeType = spec.pop(0)
-		self.__type = spec.pop(0)
-		self.__id = Id(spec.pop(0))
-		if spec.pop(0) == 'parent':
-			self.__parent = Id(spec.pop(0))
-		else:
-			self.__parent = Id() if self.__nodeType == 'class' else None
+        self._params = self._filterParams(spec)
 
-		self.__params = self.__filterParams(spec)
+    def _filterParams(self, spec):
+        params = []
+        while spec:
+            item = spec.pop(0)
+            if item == 'leaf':  # remove unwanted "leaf" specs
+                spec.pop(0)
+            else:
+                params.append(item)
+        return params
 
+    def getParent(self):
+        return self._parent
 
-	def __filterParams(self, spec):
-		spec = filter(None, spec)
-		params = []
-		while spec:
-			item = spec.pop(0)
-			if item == 'leaf': # remove unwanted "leaf" specs
-				spec.pop(0)
-			else:
-				params.append(item)
-		return params
+    def getNodeSpec(self):
+        desc = '<br/>'.join(textwrap.wrap(' '.join(self._params), 30)) or ' '
+        label = '<font color="blue">%s</font><br/>%s<br/><font point-size="10">%s</font>' % (
+        self._id, self._type, desc)
+        shape = 'box' if self._nodeType == 'qdisc' else 'ellipse'
+        return '"%s" [ label = <%s>, shape = "%s" ];' % (self._id, label, shape)
 
-
-	def getParent(self):
-		return self.__parent
-
-
-	def getNodeSpec(self):
-		desc = '<br/>'.join(textwrap.wrap(' '.join(self.__params), 30)) or ' '
-		label = '<font color="blue">%s</font><br/>%s<br/><font point-size="10">%s</font>' % (self.__id, self.__type, desc)
-		shape = 'box' if self.__nodeType == 'qdisc' else 'ellipse'
-		return '"%s" [ label = <%s>, shape = "%s" ];' % (self.__id, label, shape)
-
-
-	def getEdgeSpec(self):
-		if self.__parent is None:
-			return ''
-		return '"%s" -> "%s" [ arrowhead = "none", arrowtail = "normal"];' % (self.__parent, self.__id)
+    def getEdgeSpec(self):
+        if self._parent is None:
+            return ''
+        return '"%s" -> "%s" [ arrowhead = "none", arrowtail = "normal"];' % (self._parent, self._id)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ for more information.
 Requirements
 ------------
 
-* 2.5 &le; Python &lt; 3.0
+* 3.0 &le; Python
 * [Graphviz](http://www.graphviz.org)
 
+How to use
+----------
+
+`./tcviz.py eth0 | dot -Tpng > tc.png`
 
 Examples
 --------

--- a/tcviz.py
+++ b/tcviz.py
@@ -6,67 +6,77 @@
 # Copyright (c) 2009-2013 Vita Smid <http://ze.phyr.us>
 
 
-import subprocess, sys
-from Node import Node
+import subprocess
+import sys
+
 from Filter import Filter
+from Node import Node
 
 TCPATH = '/sbin/tc'
 
+
 def main():
-	if len(sys.argv) == 2:
-		(q, c, f) = [ readTc([type, 'show', 'dev', sys.argv[1]]) for type in ('qdisc', 'class', 'filter') ]
-	elif len(sys.argv) == 4:
-		(q, c, f) = [ readFile(p) for p in sys.argv[1:4] ]
-	else:
-		usage()
-		return 1
+    f = ''
+    if len(sys.argv) == 2:
+        (q, c) = [readTc([type, 'show', 'dev', sys.argv[1]]) for type in ('qdisc', 'class')]
+    elif len(sys.argv) == 4:
+        (q, c, f) = [readFile(p) for p in sys.argv[1:4]]
+    else:
+        usage()
+        return 1
 
-	nodes = parse(q, Node) + parse(c, Node)
-	filters = parse(f, Filter)
+    qdiscs = parse(q, Node)
+    classes = parse(c, Node)
 
-	gv = 'digraph tc { %s \n %s \n %s \n %s }' % (genSetup(), genNodes(nodes), genEdges(nodes), genEdges(filters))
-	print gv
-	return 0
+    if len(sys.argv) == 2:
+        f = '\n'.join([readTc(['filter', 'show', 'dev', sys.argv[1], 'parent', str(cur._id)]).replace('filter', 'filter parent {}'.format(cur._id)) for cur in qdiscs])
+
+    filters = parse(f, Filter)
+
+    nodes = qdiscs + classes
+    gv = 'digraph tc { %s \n %s \n %s \n %s }' % (genSetup(), genNodes(nodes), genEdges(nodes), genEdges(filters))
+    print(gv)
+    return 0
 
 
 def usage():
-	print >>sys.stderr, 'Usage: %s <interface>' % sys.argv[0]
-	print >>sys.stderr, '\nOR'
-	print >>sys.stderr, 'If you want to feed tcviz with offline data:'
-	print >>sys.stderr, '%s <qdiscs file> <classes file> <filters file>' % sys.argv[0]
+    print('Usage: %s <interface>' % sys.argv[0], file=sys.stderr)
+    print('\nOR', file=sys.stderr)
+    print('If you want to feed tcviz with offline data:', file=sys.stderr)
+    print('%s <qdiscs file> <classes file> <filters file>' % sys.argv[0], file=sys.stderr)
 
 
 def readFile(path):
-	return open(path).read()
+    return open(path).read()
 
 
 def readTc(args):
-	return subprocess.Popen([TCPATH] + args, stdout = subprocess.PIPE).communicate()[0]
+    return subprocess.Popen([TCPATH] + args, stdout=subprocess.PIPE, universal_newlines=True).communicate()[0]
 
 
 def parse(string, constructor):
-	specs = []
-	for line in string.split('\n'):
-		if not line:
-			continue
-		elif line[:2] == '  ': # continuation of the previous line
-			specs[-1] += ' ' + line.strip()
-		else:
-			specs.append(line.strip())
-	return [ constructor(spec) for spec in specs ]
+    specs = []
+    for line in string.split('\n'):
+        if not line:
+            continue
+        elif line[:2] == '  ':  # continuation of the previous line
+            specs[-1] += ' ' + line.strip()
+        else:
+            specs.append(line.strip())
+    return [constructor(spec) for spec in specs]
 
 
 def genSetup():
-	return 'node [ fontname = "DejaVu Sans" ]; edge [ fontname = "DejaVu Sans" ];'
+    return 'node [ fontname = "DejaVu Sans" ]; edge [ fontname = "DejaVu Sans" ];'
 
 
 def genNodes(objects):
-	return '\n'.join([ o.getNodeSpec() for o in objects ])
+    return '\n'.join([o.getNodeSpec() for o in objects])
 
 
 def genEdges(objects):
-	return '\n'.join([ o.getEdgeSpec() for o in objects ])
+    return '\n'.join([o.getEdgeSpec() for o in objects])
 
 
 if __name__ == '__main__':
-	sys.exit(main())
+    sys.exit(main())


### PR DESCRIPTION
fixed bugs:
classes were always rooted in the root qdisc
filters were only shown for the root qdisc

other:
ported to Python 3
added "How to use" section in README.md
formatted code (e.g. replaced tabs with whitespaces)

Maybe someone other than myself still uses this code ;)