### PR TITLE
fix continuation of lines from tc output

### DIFF
--- a/tcviz.py
+++ b/tcviz.py
@@ -59,7 +59,7 @@ def parse(string, constructor):
     for line in string.split('\n'):
         if not line:
             continue
-        elif line[:2] == '  ':  # continuation of the previous line
+        elif line.startswith(' ') or line.startswith('\t'):  # continuation of the previous line
             specs[-1] += ' ' + line.strip()
         else:
             specs.append(line.strip())


### PR DESCRIPTION
I used WonderShaper to set a rate limit of an interface, and then I ran tcviz.py with the interface as argument, but it did not work due to an error.

Finally, I found that `tc filter show dev eth1 parent ffff:` prints
```
filter protocol ip pref 50 u32
filter protocol ip pref 50 u32 fh 800: ht divisor 1
filter protocol ip pref 50 u32 fh 800::800 order 2048 key ht 800 bkt 0 flowid :1
  match 00000000/00000000 at 12
 police 0x2 rate 20Mbit burst 10Kb mtu 2Kb action drop overhead 0b
        ref 1 bind 1
```
And the last 4 lines describe just 1 filter, but they are not parsed this way.