### PR TITLE
Add support for filters attached to inner classes; add edge [qdisc]->[default_class]

### DIFF
--- a/Node.py
+++ b/Node.py
@@ -6,6 +6,7 @@
 
 import textwrap
 
+from Filter import Filter
 from Id import Id
 
 
@@ -53,6 +54,11 @@ class Node:
         return '"%s" [ label = <%s>, shape = "%s" ];' % (self._id, label, shape)
 
     def getEdgeSpec(self):
-        if self._parent is None:
-            return ''
-        return '"%s" -> "%s" [ arrowhead = "none", arrowtail = "normal"];' % (self._parent, self._id)
+        ret = ''
+        if self._parent:
+            ret = '"%s" -> "%s" [ arrowhead = "none", arrowtail = "normal"];' % (self._parent, self._id)
+
+        if self._nodeType == 'qdisc' and 'default' in self._params:
+            dcls_minor = self._params[self._params.index('default') + 1].lstrip('0x')
+            ret += '\n' + Filter('  {0}: default classid {0}:{1}'.format(self._id._major, dcls_minor)).getEdgeSpec()
+        return ret

--- a/README.md
+++ b/README.md
@@ -52,3 +52,4 @@ Contributors
 
 * Stefan Forstenlechner ([t-h-e](https://github.com/t-h-e)) stefanforstenlechner@gmail.com
 * [@qnnnnez](https://github.com/qnnnnez)
+* [@iDawer](https://github.com/iDawer)

--- a/tcviz.py
+++ b/tcviz.py
@@ -8,6 +8,7 @@
 
 import subprocess
 import sys
+from itertools import chain
 
 from Filter import Filter
 from Node import Node
@@ -29,7 +30,7 @@ def main():
     classes = parse(c, Node)
 
     if len(sys.argv) == 2:
-        f = '\n'.join([readTc(['filter', 'show', 'dev', sys.argv[1], 'parent', str(cur._id)]).replace('filter', 'filter parent {}'.format(cur._id)) for cur in qdiscs])
+        f = '\n'.join([readTc(['filter', 'show', 'dev', sys.argv[1], 'parent', str(cur._id)]).replace('filter', 'filter parent {}'.format(cur._id)) for cur in chain(qdiscs, classes)])
 
     filters = parse(f, Filter)
 


### PR DESCRIPTION
Hi!
[man7.org/tc.8#FILTERS](http://man7.org/linux/man-pages/man8/tc.8.html#FILTERS) says filters can be attached to a class:

> All filters attached  to the class are called, until one of them returns with a verdict.

So I added support for it. And also added an edge showing default class for qdisc.
Example:
![example](https://user-images.githubusercontent.com/7803845/55671231-4c09bc80-58a7-11e9-999d-9fb487a73ff0.png)
