### PR TITLE
Fix ValueError when flowid is ???

### DIFF
--- a/Filter.py
+++ b/Filter.py
@@ -27,7 +27,9 @@ class Filter:
         while spec:
             item = spec.pop(0)
             if item == 'classid' or item == 'flowid':
-                self.__target = Id(spec.pop(0))
+                idval = spec.pop(0)
+                if idval != "???":
+                  self.__target = Id(idval)
             else:
                 self.__params.append(item)
 


### PR DESCRIPTION
A filter like the following:
  `tc filter add dev srvif parent 1: protocol ip u32 match ip dst 1.2.3.4/32 action drop`
is reported in "tc show filter" as:
  `filter parent 1: protocol ip [...] flowid ??? [...]`

This patch fixes:
```
Traceback (most recent call last):
  File "./tcviz.py", line 83, in <module>
    sys.exit(main())
  File "./tcviz.py", line 35, in main
    filters = parse(f, Filter)
  File "./tcviz.py", line 67, in parse
    return [constructor(spec) for spec in specs]
  File "./tcviz.py", line 67, in <listcomp>
    return [constructor(spec) for spec in specs]
  File "/home/emanuele/src/tcviz/Filter.py", line 22, in __init__
    self.parseSpec(spec)
  File "/home/emanuele/src/tcviz/Filter.py", line 31, in parseSpec
    self.__target = Id(spec.pop(0))
  File "/home/emanuele/src/tcviz/Id.py", line 9, in __init__
    (self._major, self._minor) = spec.split(':')
ValueError: not enough values to unpack (expected 2, got 1)
```